### PR TITLE
Update boost-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # boost-ci
-Boost build for Windows
+
+Boost python build for Windows
+
+Master:
+[![Build status](https://ci.appveyor.com/api/projects/status/308fwmue023k8xac/branch/master?svg=true)](https://ci.appveyor.com/project/tiagocoutinho/boost-ci/branch/master)
+
+Current build:
+[![Build status](https://ci.appveyor.com/api/projects/status/308fwmue023k8xac?svg=true)](https://ci.appveyor.com/project/tiagocoutinho/boost-ci)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ environment:
       IDL_BIN: C:\Program Files\tangoidl
       OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
-          using python : 3.7 : c:/python36/python.exe : c:/python37/include : c:/python37/libs ;
+          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,18 +85,22 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost
   - cmd: cd "C:\projects\"
+  - cmd: md boost_build
   - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.zip
-  - cmd: 7z -y x boost_1_70_0.zip -oC:\projects\
-  #VS2008 patch
+  - cmd: 7z -y x boost_1_70_0.zip -oC:\projects\boost_build\
+
+  # VS2008 patch
   - cmd: cd "C:\projects\"
   - cmd: appveyor DownloadFile https://github.com/menpo/condaci/raw/master/vs2008_patch.zip
   - cmd: 7z -y x vs2008_patch.zip -oC:\projects\vs2008_patch\
   - cmd: if %ARCH%==x64-msvc9 call C:\projects\vs2008_patch\setup_x64.bat
   - cmd: if %ARCH%==x32-msvc9 call C:\projects\vs2008_patch\setup_x86.bat
   - cmd: if %ARCH%==x64-msvc9 copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat"
+
   # adding a boost-config.jam file
   - cmd: echo %BOOST_CFG% >> %HOMEDRIVE%%HOMEPATH%\user-config.jam
   - cmd: type %HOMEDRIVE%%HOMEPATH%\user-config.jam
+  - cmd: cd "C:\projects\boost-ci"
   
 install:
   # Setting Visual Compiler
@@ -108,10 +112,10 @@ install:
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
   # building bootstrap
-  - cmd: cd C:/projects/boost_1_70_0
-  - cmd: C:/projects/boost_1_70_0/bootstrap.bat
-  
-#clone_folder: C:\projects\boost-ci
+  - cmd: cd C:/projects/boost_build/boost_1_70_0
+  - cmd: C:/projects/boost_build/boost_1_70_0/bootstrap.bat
+
+clone_folder: C:\projects\boost-ci
 
 build:
   parallel: true
@@ -119,7 +123,7 @@ build:
   
 build_script:
   # static libraries
-  - cmd: cd C:/projects/boost_1_70_0
+  - cmd: cd C:/projects/boost_build/boost_1_70_0
   - cmd: if %ARCH%==win32-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=static runtime-link=static install
   - cmd: if %ARCH%==x64-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=static runtime-link=static install
   - cmd: if %ARCH%==win32-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=static runtime-link=static install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -180,15 +180,15 @@ build:
 build_script:
   # static libraries
   - cmd: cd C:/projects/boost_build/boost_1_64_0
-  - cmd: if %ARCH%==win32-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=static runtime-link=static install
-  - cmd: if %ARCH%==x64-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=static runtime-link=static install
-  - cmd: if %ARCH%==win32-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=static runtime-link=static install
-  - cmd: if %ARCH%==x64-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==win32-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==x64-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==win32-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==x64-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=static runtime-link=static install
   # shared libraries
-  - cmd: if %ARCH%==win32-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=shared runtime-link=shared install
-  - cmd: if %ARCH%==x64-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=shared runtime-link=shared install
-  - cmd: if %ARCH%==win32-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=shared runtime-link=shared install
-  - cmd: if %ARCH%==x64-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==win32-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==x64-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==win32-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==x64-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=shared runtime-link=shared install
 
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -180,15 +180,15 @@ build:
 build_script:
   # static libraries
   - cmd: cd C:/projects/boost_build/boost_1_64_0
-  - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=static runtime-link=static
-  - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=static runtime-link=static
-  - cmd: if %ARCH%==win32-msvc14 b2 --with-python toolset=msvc-14.0 address-model=32 install link=static runtime-link=static
-  - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=static runtime-link=static
+  - cmd: if %ARCH%==win32-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==x64-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==win32-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=static runtime-link=static install
+  - cmd: if %ARCH%==x64-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=static runtime-link=static install
   # shared libraries
-  - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==win32-msvc14 b2 --with-python toolset=msvc-14.0 address-model=32 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==win32-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==x64-msvc9 b2 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==win32-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=shared runtime-link=shared install
+  - cmd: if %ARCH%==x64-msvc14 b2 --with-python variant=release toolset=msvc-14.0 address-model=64 threading=multi link=shared runtime-link=shared install
 
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,7 +111,7 @@ install:
   - cmd: cd C:/projects/boost_1_70_0
   - cmd: C:/projects/boost_1_70_0/bootstrap.bat
   
-clone_folder: C:\projects\boost_1_70_0
+clone_folder: C:\projects\boost-ci
 
 build:
   parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,46 +5,9 @@ branches:
 
 image: Visual Studio 2015
 
+
 environment:
   matrix:
-    - platform: x64
-      ARCH: x64-msvc9
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
-      MSVCVERSION: v90
-      MSVCYEAR: "vs2008"
-      MSVCABR: "9"
-      VC_VER: 9.0
-      PYTHONPATH: c:\Python27-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python27-x64/python"
-      PY_VER: 27
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-9.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-      BOOST_CFG: >-
-          using python : 2.7 : c:/python27-x64/python.exe : c:/python27-x64/include : c:/python27-x64/libs ;
-    - platform: win32
-      ARCH: win32-msvc10
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 10 2010"
-      MSVCVERSION: v100
-      MSVCYEAR: "vs2010"
-      MSVCABR: "10"
-      VC_VER: 10.0
-      PYTHONPATH: c:\Python34\
-      PYTHONPATHOMNI: "/cygdrive/c/Python34/python"
-      PY_VER: 34
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-10.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files (x86)\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-      BOOST_CFG: >-
-          using python : 3.4 : c:/python34/python.exe : c:/python34/include : c:/python34/libs ;
     - platform: win32
       ARCH: win32-msvc9
       configuration: Release
@@ -65,62 +28,44 @@ environment:
       BOOST_CFG: >-
           using python : 2.7 : c:/python27/python.exe : c:/python27/include : c:/python27/libs ;
     - platform: x64
-      ARCH: x64-msvc10
+      ARCH: x64-msvc9
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
-      MSVCVERSION: v100
-      MSVCYEAR: "vs2010"
-      MSVCABR: "10"
-      VC_VER: 10.0
-      PYTHONPATH: c:\Python34-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python34-x64/python"
-      PY_VER: 34
+      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
+      MSVCVERSION: v90
+      MSVCYEAR: "vs2008"
+      MSVCABR: "9"
+      VC_VER: 9.0
+      PYTHONPATH: c:\Python27-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python27-x64/python"
+      PY_VER: 27
       BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-10.0
+      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-9.0
       ZMQ_BASE: C:\projects\libzmq
       IDL_BASE: C:\projects\tangoidl
       IDL_BIN: C:\Program Files\tangoidl
       OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
-          using python : 3.4 : c:/python34-x64/python.exe : c:/python34-x64/include : c:/python34-x64/libs ;
-    - platform: x64
-      ARCH: x64-msvc12
+          using python : 2.7 : c:/python27-x64/python.exe : c:/python27-x64/include : c:/python27-x64/libs ;
+
+    - platform: win32
+      ARCH: win32-msvc14
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
-      MSVCVERSION: v120
-      MSVCYEAR: "vs2013"
-      MSVCABR: "13"
-      VC_VER: 13.0
-      PYTHONPATH: c:\Python34-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python34-x64/python"
-      PY_VER: 34
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-12.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-      BOOST_CFG: >-
-          using python : 3.4 : c:/python34-x64/python.exe : c:/python34-x64/include : c:/python34-x64/libs ;
-    - platform: x64
-      ARCH: x64-msvc14
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      CMAKE_GENERATOR: "Visual Studio 14 2015"
       MSVCVERSION: v140
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
-      PYTHONPATH: c:\Python35-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python35-x64/python"
-      PY_VER: 35
+      PYTHONPATH: c:\Python36\
+      PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
+      PY_VER: 36
       BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-14.0
+      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-14.0
       ZMQ_BASE: C:\projects\libzmq
       IDL_BASE: C:\projects\tangoidl
       IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1    
+      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
-          using python : 3.5 : c:/python35-x64/python.exe : c:/python35-x64/include : c:/python35-x64/libs ;
+          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release
@@ -137,9 +82,49 @@ environment:
       ZMQ_BASE: C:\projects\libzmq
       IDL_BASE: C:\projects\tangoidl
       IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1    
+      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
+
+    - platform: win32
+      ARCH: win32-msvc14
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 14 2015"
+      MSVCVERSION: v140
+      MSVCYEAR: "vs2015"
+      MSVCABR: "14"
+      VC_VER: 14.0
+      PYTHONPATH: c:\Python37-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
+      PY_VER: 37
+      BOOST_ROOT: C:/local/boost_1_64_0
+      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-14.0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python36/python.exe : c:/python37/include : c:/python37/libs ;
+    - platform: x64
+      ARCH: x64-msvc14
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      MSVCVERSION: v140
+      MSVCYEAR: "vs2015"
+      MSVCABR: "14"
+      VC_VER: 14.0
+      PYTHONPATH: c:\Python37-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
+      PY_VER: 37
+      BOOST_ROOT: C:/local/boost_1_64_0
+      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-14.0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+
 init:
   # go to hell Xamarin (see http://help.appveyor.com/discussions/problems/4569)
   - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
@@ -177,10 +162,7 @@ install:
   - cmd: if %ARCH%==win32-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==win32-msvc9 set path=C:\Windows\Microsoft.NET\Framework\v4.0.30319;%path%
   - cmd: if %ARCH%==x64-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat"
-  - cmd: if %ARCH%==win32-msvc10 call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
-  - cmd: if %ARCH%==win32-msvc10 set path=C:\Windows\Microsoft.NET\Framework\v4.0.30319;%path%
-  - cmd: if %ARCH%==x64-msvc10 call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 
-  - cmd: if %ARCH%==x64-msvc12 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+  - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%Platform%'"
@@ -200,16 +182,12 @@ build_script:
   - cmd: cd C:/projects/boost_build/boost_1_64_0
   - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=static runtime-link=static
   - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=static runtime-link=static
-  - cmd: if %ARCH%==win32-msvc10 b2 --with-python toolset=msvc-10.0 address-model=32 install link=static runtime-link=static
-  - cmd: if %ARCH%==x64-msvc10 b2 --with-python toolset=msvc-10.0 address-model=64 install link=static runtime-link=static
-  - cmd: if %ARCH%==x64-msvc12 b2 --with-python toolset=msvc-12.0 address-model=64 install link=static runtime-link=static
+  - cmd: if %ARCH%==win32-msvc14 b2 --with-python toolset=msvc-14.0 address-model=32 install link=static runtime-link=static
   - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=static runtime-link=static
   # shared libraries
   - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=shared runtime-link=shared
   - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==win32-msvc10 b2 --with-python toolset=msvc-10.0 address-model=32 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==x64-msvc10 b2 --with-python toolset=msvc-10.0 address-model=64 install link=shared runtime-link=shared
-  - cmd: if %ARCH%==x64-msvc12 b2 --with-python toolset=msvc-12.0 address-model=64 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==win32-msvc14 b2 --with-python toolset=msvc-14.0 address-model=32 install link=shared runtime-link=shared
   - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=shared runtime-link=shared
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -196,14 +196,21 @@ build:
   verbosity: minimal
   
 build_script:
+  # static libraries
   - cmd: cd C:/projects/boost_build/boost_1_64_0
-  - cmd: if %ARCH%==win32-msvc9 b2 toolset=msvc-9.0 address-model=32 install link=static runtime-link=static,shared
-  - cmd: if %ARCH%==x64-msvc9 b2 toolset=msvc-9.0 address-model=64 install link=static runtime-link=static,shared
-  - cmd: if %ARCH%==win32-msvc10 b2 toolset=msvc-10.0 address-model=32 install link=static runtime-link=static,shared
-  - cmd: if %ARCH%==x64-msvc10 b2 toolset=msvc-10.0 address-model=64 install link=static runtime-link=static,shared
-  - cmd: if %ARCH%==x64-msvc12 b2 toolset=msvc-12.0 address-model=64 install link=static runtime-link=static,shared
-  - cmd: if %ARCH%==x64-msvc14 b2 toolset=msvc-14.0 address-model=64 install link=static runtime-link=static,shared
-
+  - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=static runtime-link=static
+  - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=static runtime-link=static
+  - cmd: if %ARCH%==win32-msvc10 b2 --with-python toolset=msvc-10.0 address-model=32 install link=static runtime-link=static
+  - cmd: if %ARCH%==x64-msvc10 b2 --with-python toolset=msvc-10.0 address-model=64 install link=static runtime-link=static
+  - cmd: if %ARCH%==x64-msvc12 b2 --with-python toolset=msvc-12.0 address-model=64 install link=static runtime-link=static
+  - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=static runtime-link=static
+  # shared libraries
+  - cmd: if %ARCH%==win32-msvc9 b2 --with-python toolset=msvc-9.0 address-model=32 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==x64-msvc9 b2 --with-python toolset=msvc-9.0 address-model=64 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==win32-msvc10 b2 --with-python toolset=msvc-10.0 address-model=32 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==x64-msvc10 b2 --with-python toolset=msvc-10.0 address-model=64 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==x64-msvc12 b2 --with-python toolset=msvc-12.0 address-model=64 install link=shared runtime-link=shared
+  - cmd: if %ARCH%==x64-msvc14 b2 --with-python toolset=msvc-14.0 address-model=64 install link=shared runtime-link=shared
 
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,123 +5,74 @@ branches:
 
 image: Visual Studio 2015
 
-
 environment:
   matrix:
     - platform: win32
       ARCH: win32-msvc9
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 9 2008"
       MSVCVERSION: v90
       MSVCYEAR: "vs2008"
       MSVCABR: "9"
       VC_VER: 9.0
       PYTHONPATH: c:\Python27\
-      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
       PY_VER: 27
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-9.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files (x86)\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 2.7 : c:/python27/python.exe : c:/python27/include : c:/python27/libs ;
     - platform: x64
       ARCH: x64-msvc9
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
       MSVCVERSION: v90
       MSVCYEAR: "vs2008"
       MSVCABR: "9"
       VC_VER: 9.0
       PYTHONPATH: c:\Python27-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python27-x64/python"
       PY_VER: 27
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-9.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 2.7 : c:/python27-x64/python.exe : c:/python27-x64/include : c:/python27-x64/libs ;
 
     - platform: win32
       ARCH: win32-msvc14
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015"
       MSVCVERSION: v140
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
       PYTHONPATH: c:\Python36\
-      PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
       PY_VER: 36
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-14.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
       MSVCVERSION: v140
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
       PYTHONPATH: c:\Python36-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
       PY_VER: 36
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-14.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
 
     - platform: win32
       ARCH: win32-msvc14
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015"
       MSVCVERSION: v140
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
       PYTHONPATH: c:\Python37-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
       PY_VER: 37
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib32-msvc-14.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
       MSVCVERSION: v140
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
       PYTHONPATH: c:\Python37-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
       PY_VER: 37
-      BOOST_ROOT: C:/local/boost_1_64_0
-      BOOST_LIBS: C:/local/boost_1_64_0/lib64-msvc-14.0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
       BOOST_CFG: >-
           using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
 
@@ -134,16 +85,8 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost
   - cmd: cd "C:\projects\"
-  - cmd: md boost_build
-  - cmd: cd "C:\projects\"
-  - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.zip
-  - cmd: 7z -y x boost_1_64_0.zip -oC:\projects\boost_build\
-  #Pthread-Win32
-  - cmd: cd "C:\projects\"
-  - cmd: md pthreads-win32
-  - cmd: cd "C:\projects\"
-  - appveyor DownloadFile "http://www.mirrorservice.org/sites/sources.redhat.com/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip"
-  - cmd: 7z -y x pthreads-w32-2-9-1-release.zip -oC:\projects\pthreads-win32\
+  - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.zip
+  - cmd: 7z -y x boost_1_70_0.zip -oC:\projects\
   #VS2008 patch
   - cmd: cd "C:\projects\"
   - cmd: appveyor DownloadFile https://github.com/menpo/condaci/raw/master/vs2008_patch.zip
@@ -154,24 +97,21 @@ init:
   # adding a boost-config.jam file
   - cmd: echo %BOOST_CFG% >> %HOMEDRIVE%%HOMEPATH%\user-config.jam
   - cmd: type %HOMEDRIVE%%HOMEPATH%\user-config.jam
-  - cmd: cd "C:\projects\boost-ci"
   
 install:
   # Setting Visual Compiler
-  - cmd: cd "C:\projects\"
   - cmd: if %ARCH%==win32-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==win32-msvc9 set path=C:\Windows\Microsoft.NET\Framework\v4.0.30319;%path%
   - cmd: if %ARCH%==x64-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat"
   - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-  - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
   # building bootstrap
-  - cmd: cd C:/projects/boost_build/boost_1_64_0
-  - cmd: C:/projects/boost_build/boost_1_64_0/bootstrap.bat
+  - cmd: cd C:/projects/boost_1_70_0
+  - cmd: C:/projects/boost_1_70_0/bootstrap.bat
   
-clone_folder: C:\projects\boost-ci
+clone_folder: C:\projects\boost_1_70_0
 
 build:
   parallel: true
@@ -179,7 +119,7 @@ build:
   
 build_script:
   # static libraries
-  - cmd: cd C:/projects/boost_build/boost_1_64_0
+  - cmd: cd C:/projects/boost_1_70_0
   - cmd: if %ARCH%==win32-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=32 threading=multi link=static runtime-link=static install
   - cmd: if %ARCH%==x64-msvc9 b2 -j4 --with-python variant=release toolset=msvc-9.0 address-model=64 threading=multi link=static runtime-link=static install
   - cmd: if %ARCH%==win32-msvc14 b2 -j4 --with-python variant=release toolset=msvc-14.0 address-model=32 threading=multi link=static runtime-link=static install
@@ -194,8 +134,8 @@ build_script:
 after_build:
   - cmd: cd C:/boost
   - cmd: dir
-  - 7z a boost-1.64_%ARCH%_%PY_VER%.zip C:/boost
-  - move boost-1.64_%ARCH%_%PY_VER%.zip c:/projects/boost-ci/
+  - 7z a boost-1.70.0_%ARCH%_%PY_VER%.zip C:/boost
+  - move boost-1.70.0_%ARCH%_%PY_VER%.zip c:/projects/boost-ci/
 
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,7 +111,7 @@ install:
   - cmd: cd C:/projects/boost_1_70_0
   - cmd: C:/projects/boost_1_70_0/bootstrap.bat
   
-clone_folder: C:\projects\boost-ci
+#clone_folder: C:\projects\boost-ci
 
 build:
   parallel: true


### PR DESCRIPTION
- Update boost to 1.70.0
- Add missing build for python 3.6 32Bits
- Add build for python 3.7 (32 and 64bits)
- Only build boost-python, multithreaded, release, static and dynamic lib (reduce binary size from 200Mb to 20Mb and appveyor build to 3minutes)
- Fix several errors mixing python and platform versions