### PR TITLE
Add Python 3.8 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,31 +3,14 @@ branches:
   only:
     - master
 
-image: Visual Studio 2015
+image: Visual Studio 2019
 
 environment:
   matrix:
     - platform: win32
       ADDR_MODEL: 32
-      ARCH: win32-msvc9
-      MSVCVERSION: 9.0
-      PYTHONPATH: c:\Python27\
-      PY_VER: 27
-      BOOST_CFG: >-
-          using python : 2.7 : c:/python27/python.exe : c:/python27/include : c:/python27/libs ;
-    - platform: x64
-      ADDR_MODEL: 64
-      ARCH: x64-msvc9
-      MSVCVERSION: 9.0
-      PYTHONPATH: c:\Python27-x64\
-      PY_VER: 27
-      BOOST_CFG: >-
-          using python : 2.7 : c:/python27-x64/python.exe : c:/python27-x64/include : c:/python27-x64/libs ;
-
-    - platform: win32
-      ADDR_MODEL: 32
       ARCH: win32-msvc14
-      MSVCVERSION: 14.0
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python36\
       PY_VER: 36
       BOOST_CFG: >-
@@ -35,7 +18,7 @@ environment:
     - platform: x64
       ADDR_MODEL: 64
       ARCH: x64-msvc14
-      MSVCVERSION: 14.0
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python36-x64\
       PY_VER: 36
       BOOST_CFG: >-
@@ -44,40 +27,45 @@ environment:
     - platform: win32
       ADDR_MODEL: 32
       ARCH: win32-msvc14
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python37-x64\
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python37\
       PY_VER: 37
       BOOST_CFG: >-
           using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
     - platform: x64
       ADDR_MODEL: 64
       ARCH: x64-msvc14
-      MSVCVERSION: 14.0
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python37-x64\
       PY_VER: 37
       BOOST_CFG: >-
           using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+          
+    - platform: win32
+      ADDR_MODEL: 32
+      ARCH: win32-msvc14
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python38\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
+    - platform: x64
+      ADDR_MODEL: 64
+      ARCH: x64-msvc14
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python38-x64\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
 
 init:
-  # go to hell Xamarin (see http://help.appveyor.com/discussions/problems/4569)
-  - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
-  - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-  - del "C:\Program Files (x86)\MSBuild\12.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
   #RDP from start
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost
   - cmd: cd "C:\projects\"
   - cmd: md boost_build
-  - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.zip
-  - cmd: 7z -y x boost_1_70_0.zip -oC:\projects\boost_build\
-
-  # VS2008 patch
-  - cmd: cd "C:\projects\"
-  - cmd: appveyor DownloadFile https://github.com/menpo/condaci/raw/master/vs2008_patch.zip
-  - cmd: 7z -y x vs2008_patch.zip -oC:\projects\vs2008_patch\
-  - cmd: if %ARCH%==x64-msvc9 call C:\projects\vs2008_patch\setup_x64.bat
-  - cmd: if %ARCH%==x32-msvc9 call C:\projects\vs2008_patch\setup_x86.bat
-  - cmd: if %ARCH%==x64-msvc9 copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat"
+  - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.zip
+  - cmd: 7z -y x boost_1_73_0.zip -oC:\projects\boost_build\
 
   # adding a boost-config.jam file
   - cmd: echo %BOOST_CFG% >> %HOMEDRIVE%%HOMEPATH%\user-config.jam
@@ -86,16 +74,11 @@ init:
   
 install:
   # Setting Visual Compiler
-  - cmd: if %ARCH%==win32-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat"
-  - cmd: if %ARCH%==win32-msvc9 set path=C:\Windows\Microsoft.NET\Framework\v4.0.30319;%path%
-  - cmd: if %ARCH%==x64-msvc9 call "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat"
-  - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
-  - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
   # building bootstrap
-  - cmd: cd C:/projects/boost_build/boost_1_70_0
-  - cmd: C:/projects/boost_build/boost_1_70_0/bootstrap.bat
+  - cmd: cd C:/projects/boost_build/boost_1_73_0
+  - cmd: C:/projects/boost_build/boost_1_73_0/bootstrap.bat
 
 clone_folder: C:\projects\boost-ci
 
@@ -104,7 +87,7 @@ build:
   verbosity: minimal
   
 build_script:
-  - cmd: cd C:/projects/boost_build/boost_1_70_0
+  - cmd: cd C:/projects/boost_build/boost_1_73_0
   # static libraries
   - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=static runtime-link=static install
   # shared libraries
@@ -114,8 +97,8 @@ build_script:
 after_build:
   - cmd: cd C:/boost
   - cmd: dir
-  - 7z a boost-python-1.70.0_%ARCH%_py%PY_VER%.zip C:/boost
-  - move boost-python-1.70.0_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
+  - 7z a boost-python-1.73.0_%ARCH%_py%PY_VER%.zip C:/boost
+  - move boost-python-1.73.0_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
 
 
 on_finish:


### PR DESCRIPTION
Fixes #2 and a couple of updates on the road:

 - Use Visual Studio 2019 image
 - Build with MSVC 2019 (binary compatible with 2015)
 - Update boost to 1.73
 - Drop build for Python 2.7