### PR TITLE
Update to Boost 1.82.0, add Python 3.9 to 3.11 support, MSVC 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,60 +4,76 @@ branches:
     - master
     - support-new-python-versions
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 environment:
   matrix:
+    # - platform: win32
+    #   ADDR_MODEL: 32
+    #   ARCH: win32-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python36\
+    #   PY_VER: 36
+    #   BOOST_CFG: >-
+    #       using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
+    # - platform: x64
+    #   ADDR_MODEL: 64
+    #   ARCH: x64-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python36-x64\
+    #   PY_VER: 36
+    #   BOOST_CFG: >-
+    #       using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
+
+    # - platform: win32
+    #   ADDR_MODEL: 32
+    #   ARCH: win32-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python37\
+    #   PY_VER: 37
+    #   BOOST_CFG: >-
+    #       using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
+    # - platform: x64
+    #   ADDR_MODEL: 64
+    #   ARCH: x64-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python37-x64\
+    #   PY_VER: 37
+    #   BOOST_CFG: >-
+    #       using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+
+    # - platform: win32
+    #   ADDR_MODEL: 32
+    #   ARCH: win32-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python38\
+    #   PY_VER: 38
+    #   BOOST_CFG: >-
+    #       using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
+    # - platform: x64
+    #   ADDR_MODEL: 64
+    #   ARCH: x64-msvc14
+    #   MSVCVERSION: 14.0
+    #   PYTHONPATH: c:\Python38-x64\
+    #   PY_VER: 38
+    #   BOOST_CFG: >-
+    #       using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
     - platform: win32
       ADDR_MODEL: 32
       ARCH: win32-msvc14
       MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python36\
-      PY_VER: 36
+      PYTHONPATH: c:\Python39\
+      PY_VER: 39
       BOOST_CFG: >-
-          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
+          using python : 3.9 : c:/python39/python.exe : c:/python39/include : c:/python39/libs ;
     - platform: x64
       ADDR_MODEL: 64
       ARCH: x64-msvc14
       MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python36-x64\
-      PY_VER: 36
-      BOOST_CFG: >-
-          using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
-
-    - platform: win32
-      ADDR_MODEL: 32
-      ARCH: win32-msvc14
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python37\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-    - platform: x64
-      ADDR_MODEL: 64
-      ARCH: x64-msvc14
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python37-x64\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
-
-    - platform: win32
-      ADDR_MODEL: 32
-      ARCH: win32-msvc14
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python38\
+      PYTHONPATH: c:\Python39-x64\
       PY_VER: 38
       BOOST_CFG: >-
-          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-    - platform: x64
-      ADDR_MODEL: 64
-      ARCH: x64-msvc14
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python38-x64\
-      PY_VER: 38
-      BOOST_CFG: >-
-          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+          using python : 3.9 : c:/python39-x64/python.exe : c:/python39-x64/include : c:/python39-x64/libs ;
 
 init:
   - cmd: echo "List all projects and Python versions"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: 1.0.{build}
 branches:
   only:
     - master
+    - support-new-python-versions
 
 image: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
     - master
     - support-new-python-versions
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,17 +58,19 @@ environment:
     #   PY_VER: 38
     #   BOOST_CFG: >-
     #       using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
-    - platform: win32
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: win32
       ADDR_MODEL: 32
-      ARCH: win32-msvc14
+      ARCH: v142_x86
       MSVCVERSION: 14.2
       PYTHONPATH: c:\Python39\
       PY_VER: 39
       BOOST_CFG: >-
           using python : 3.9 : c:/python39/python.exe : c:/python39/include : c:/python39/libs ;
-    - platform: x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: x64
       ADDR_MODEL: 64
-      ARCH: x64-msvc14
+      ARCH: v142_x64
       MSVCVERSION: 14.2
       PYTHONPATH: c:\Python39-x64\
       PY_VER: 38
@@ -84,8 +86,8 @@ init:
   # Boost
   - cmd: cd "C:\projects\"
   - cmd: md boost_build
-  - appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.zip
-  - cmd: 7z -y x boost_1_73_0.zip -oC:\projects\boost_build\
+  - appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.zip
+  - cmd: 7z -y x boost_1_82_0.zip -oC:\projects\boost_build\
 
   # adding a boost-config.jam file
   - cmd: echo %BOOST_CFG% >> %HOMEDRIVE%%HOMEPATH%\user-config.jam
@@ -97,8 +99,8 @@ install:
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
   # building bootstrap
-  - cmd: cd C:/projects/boost_build/boost_1_73_0
-  - cmd: C:/projects/boost_build/boost_1_73_0/bootstrap.bat
+  - cmd: cd C:/projects/boost_build/boost_1_82_0
+  - cmd: C:/projects/boost_build/boost_1_82_0/bootstrap.bat
 
 clone_folder: C:\projects\boost-ci
 
@@ -107,7 +109,7 @@ build:
   verbosity: minimal
 
 build_script:
-  - cmd: cd C:/projects/boost_build/boost_1_73_0
+  - cmd: cd C:/projects/boost_build/boost_1_82_0
   # static libraries
   - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=static runtime-link=static install
   # shared libraries
@@ -117,8 +119,8 @@ build_script:
 after_build:
   - cmd: cd C:/boost
   - cmd: dir
-  - 7z a boost-python-1.73.0_%ARCH%_py%PY_VER%.zip C:/boost
-  - move boost-python-1.73.0_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
+  - 7z a boost-python-1.82.0_%ARCH%_py%PY_VER%.zip C:/boost
+  - move boost-python-1.82.0_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
 
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,7 +122,6 @@ environment:
       BOOST_CFG: >-
           using python : 3.11 : c:/python311-x64/python.exe : c:/python311-x64/include : c:/python311-x64/libs ;
 
-
 init:
   - cmd: set BOOST_VERSION_UNDERSCORED=%BOOST_VERSION:.=_%
   - cmd: echo %BOOST_VERSION_UNDERSCORED%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,60 +4,62 @@ branches:
     - master
     - support-new-python-versions
 
-image: Visual Studio 2019
-
 environment:
   matrix:
-    # - platform: win32
-    #   ADDR_MODEL: 32
-    #   ARCH: win32-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python36\
-    #   PY_VER: 36
-    #   BOOST_CFG: >-
-    #       using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
-    # - platform: x64
-    #   ADDR_MODEL: 64
-    #   ARCH: x64-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python36-x64\
-    #   PY_VER: 36
-    #   BOOST_CFG: >-
-    #       using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
-
-    # - platform: win32
-    #   ADDR_MODEL: 32
-    #   ARCH: win32-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python37\
-    #   PY_VER: 37
-    #   BOOST_CFG: >-
-    #       using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-    # - platform: x64
-    #   ADDR_MODEL: 64
-    #   ARCH: x64-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python37-x64\
-    #   PY_VER: 37
-    #   BOOST_CFG: >-
-    #       using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
-
-    # - platform: win32
-    #   ADDR_MODEL: 32
-    #   ARCH: win32-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python38\
-    #   PY_VER: 38
-    #   BOOST_CFG: >-
-    #       using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-    # - platform: x64
-    #   ADDR_MODEL: 64
-    #   ARCH: x64-msvc14
-    #   MSVCVERSION: 14.0
-    #   PYTHONPATH: c:\Python38-x64\
-    #   PY_VER: 38
-    #   BOOST_CFG: >-
-    #       using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python36\
+      PY_VER: 36
+      BOOST_CFG: >-
+          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python36-x64\
+      PY_VER: 36
+      BOOST_CFG: >-
+          using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python37\
+      PY_VER: 37
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python37-x64\
+      PY_VER: 37
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python38\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python38-x64\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,60 +9,60 @@ environment:
   BOOST_VERSION_UNDERSCORED: "1_82_0"
   matrix:
   # Python 3.6
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python36\
       PY_VER: 36
       BOOST_CFG: >-
           using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: x64
       ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python36-x64\
       PY_VER: 36
       BOOST_CFG: >-
           using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
 
   # Python 3.7
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python37\
       PY_VER: 37
       BOOST_CFG: >-
           using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: x64
       ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python37-x64\
       PY_VER: 37
       BOOST_CFG: >-
           using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
 
   # Python 3.8
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python38\
       PY_VER: 38
       BOOST_CFG: >-
           using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: x64
       ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python38-x64\
       PY_VER: 38
       BOOST_CFG: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -168,7 +168,6 @@ after_build:
   - 7z a boost-python-%BOOST_VERSION%_%ARCH%_py%PY_VER%.zip C:/boost
   - move boost-python-%BOOST_VERSION%_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
 
-
 on_finish:
   #RDP for finish
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ environment:
           using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
 
 init:
-  - cmd: echo "List all projects and python versions"
+  - cmd: echo "List all projects and Python versions"
   - cmd: dir "C:\projects\"
   - cmd: dir "C:\"
   #RDP from start

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 1.0.{build}
-branches:
-  only:
-    - master
-    - support-new-python-versions
+# branches:
+#   only:
+#     - master
+#     - support-new-python-versions
 
 environment:
   BOOST_VERSION: "1.82.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,70 +1,73 @@
 version: 1.0.{build}
-# branches:
-#   only:
-#     - master
-#     - support-new-python-versions
+branches:
+  only:
+    - master
+    - support-new-python-versions
 
 environment:
   BOOST_VERSION: "1.82.0"
   BOOST_VERSION_UNDERSCORED: "1_82_0"
   matrix:
-  # # Python 3.6
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: win32
-  #     ADDR_MODEL: 32
-  #     ARCH: v140_x86
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python36\
-  #     PY_VER: 36
-  #     BOOST_CFG: >-
-  #         using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     ADDR_MODEL: 64
-  #     ARCH: v140_x64
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python36-x64\
-  #     PY_VER: 36
-  #     BOOST_CFG: >-
-  #         using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
-  # # Python 3.7
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: win32
-  #     ADDR_MODEL: 32
-  #     ARCH: v140_x86
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python37\
-  #     PY_VER: 37
-  #     BOOST_CFG: >-
-  #         using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     ADDR_MODEL: 64
-  #     ARCH: v140_x64
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python37-x64\
-  #     PY_VER: 37
-  #     BOOST_CFG: >-
-  #         using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
-  # # Python 3.8
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: win32
-  #     ADDR_MODEL: 32
-  #     ARCH: v140_x86
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python38\
-  #     PY_VER: 38
-  #     BOOST_CFG: >-
-  #         using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     ADDR_MODEL: 64
-  #     ARCH: v140_x64
-  #     MSVCVERSION: 14.0
-  #     PYTHONPATH: c:\Python38-x64\
-  #     PY_VER: 38
-  #     BOOST_CFG: >-
-  #         using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+  # Python 3.6
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python36\
+      PY_VER: 36
+      BOOST_CFG: >-
+          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python36-x64\
+      PY_VER: 36
+      BOOST_CFG: >-
+          using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
+
+  # Python 3.7
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python37\
+      PY_VER: 37
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python37-x64\
+      PY_VER: 37
+      BOOST_CFG: >-
+          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+
+  # Python 3.8
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v140_x86
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python38\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v140_x64
+      MSVCVERSION: 14.0
+      PYTHONPATH: c:\Python38-x64\
+      PY_VER: 38
+      BOOST_CFG: >-
+          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+
   # Python 3.9
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
@@ -84,6 +87,7 @@ environment:
       PY_VER: 39
       BOOST_CFG: >-
           using python : 3.9 : c:/python39-x64/python.exe : c:/python39-x64/include : c:/python39-x64/libs ;
+
   # Python 3.10
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
@@ -103,7 +107,8 @@ environment:
       PY_VER: 310
       BOOST_CFG: >-
           using python : 3.10 : c:/python310-x64/python.exe : c:/python310-x64/include : c:/python310-x64/libs ;
-    # Python 3.11
+
+  # Python 3.11
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32
@@ -124,10 +129,6 @@ environment:
           using python : 3.11 : c:/python311-x64/python.exe : c:/python311-x64/include : c:/python311-x64/libs ;
 
 init:
-  - cmd: echo %BOOST_VERSION_UNDERSCORED%
-  - cmd: echo "List all projects and Python versions"
-  - cmd: dir "C:\projects\"
-  - cmd: dir "C:\"
   #RDP from start
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ environment:
     - platform: win32
       ADDR_MODEL: 32
       ARCH: win32-msvc14
-      MSVCVERSION: 14.0
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python39\
       PY_VER: 39
       BOOST_CFG: >-
@@ -69,7 +69,7 @@ environment:
     - platform: x64
       ADDR_MODEL: 64
       ARCH: x64-msvc14
-      MSVCVERSION: 14.0
+      MSVCVERSION: 14.2
       PYTHONPATH: c:\Python39-x64\
       PY_VER: 38
       BOOST_CFG: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,61 +5,66 @@ branches:
     - support-new-python-versions
 
 environment:
+  BOOST_VERSION: "1.82.0"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python36\
-      PY_VER: 36
-      BOOST_CFG: >-
-          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python36-x64\
-      PY_VER: 36
-      BOOST_CFG: >-
-          using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python37\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python37-x64\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v140_x86
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python38\
-      PY_VER: 38
-      BOOST_CFG: >-
-          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v140_x64
-      MSVCVERSION: 14.0
-      PYTHONPATH: c:\Python38-x64\
-      PY_VER: 38
-      BOOST_CFG: >-
-          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+  # # Python 3.6
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: win32
+  #     ADDR_MODEL: 32
+  #     ARCH: v140_x86
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python36\
+  #     PY_VER: 36
+  #     BOOST_CFG: >-
+  #         using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     ADDR_MODEL: 64
+  #     ARCH: v140_x64
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python36-x64\
+  #     PY_VER: 36
+  #     BOOST_CFG: >-
+  #         using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
+  # # Python 3.7
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: win32
+  #     ADDR_MODEL: 32
+  #     ARCH: v140_x86
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python37\
+  #     PY_VER: 37
+  #     BOOST_CFG: >-
+  #         using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     ADDR_MODEL: 64
+  #     ARCH: v140_x64
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python37-x64\
+  #     PY_VER: 37
+  #     BOOST_CFG: >-
+  #         using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
+  # # Python 3.8
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: win32
+  #     ADDR_MODEL: 32
+  #     ARCH: v140_x86
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python38\
+  #     PY_VER: 38
+  #     BOOST_CFG: >-
+  #         using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     ADDR_MODEL: 64
+  #     ARCH: v140_x64
+  #     MSVCVERSION: 14.0
+  #     PYTHONPATH: c:\Python38-x64\
+  #     PY_VER: 38
+  #     BOOST_CFG: >-
+  #         using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
+  # Python 3.9
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
       ADDR_MODEL: 32
@@ -75,11 +80,52 @@ environment:
       ARCH: v142_x64
       MSVCVERSION: 14.2
       PYTHONPATH: c:\Python39-x64\
-      PY_VER: 38
+      PY_VER: 39
       BOOST_CFG: >-
           using python : 3.9 : c:/python39-x64/python.exe : c:/python39-x64/include : c:/python39-x64/libs ;
+  # Python 3.10
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python310\
+      PY_VER: 310
+      BOOST_CFG: >-
+          using python : 3.10 : c:/python310/python.exe : c:/python310/include : c:/python310/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python310-x64\
+      PY_VER: 310
+      BOOST_CFG: >-
+          using python : 3.10 : c:/python310-x64/python.exe : c:/python310-x64/include : c:/python310-x64/libs ;
+    # Python 3.11
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python311\
+      PY_VER: 311
+      BOOST_CFG: >-
+          using python : 3.11 : c:/python311/python.exe : c:/python311/include : c:/python311/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
+      PYTHONPATH: c:\Python311-x64\
+      PY_VER: 311
+      BOOST_CFG: >-
+          using python : 3.11 : c:/python311-x64/python.exe : c:/python311-x64/include : c:/python311-x64/libs ;
+
 
 init:
+  - cmd: set BOOST_VERSION_UNDERSCORED=%BOOST_VERSION:.=_%
+  - cmd: echo %BOOST_VERSION_UNDERSCORED%
   - cmd: echo "List all projects and Python versions"
   - cmd: dir "C:\projects\"
   - cmd: dir "C:\"
@@ -88,8 +134,8 @@ init:
   # Boost
   - cmd: cd "C:\projects\"
   - cmd: md boost_build
-  - appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.zip
-  - cmd: 7z -y x boost_1_82_0.zip -oC:\projects\boost_build\
+  - appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/%BOOST_VERSION%/source/boost_%BOOST_VERSION_UNDERSCORED%.zip
+  - cmd: 7z -y x boost_%BOOST_VERSION_UNDERSCORED%.zip -oC:\projects\boost_build\
 
   # adding a boost-config.jam file
   - cmd: echo %BOOST_CFG% >> %HOMEDRIVE%%HOMEPATH%\user-config.jam
@@ -101,8 +147,8 @@ install:
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
   # building bootstrap
-  - cmd: cd C:/projects/boost_build/boost_1_82_0
-  - cmd: C:/projects/boost_build/boost_1_82_0/bootstrap.bat
+  - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
+  - cmd: C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/bootstrap.bat
 
 clone_folder: C:\projects\boost-ci
 
@@ -111,7 +157,7 @@ build:
   verbosity: minimal
 
 build_script:
-  - cmd: cd C:/projects/boost_build/boost_1_82_0
+  - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
   # static libraries
   - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=static runtime-link=static install
   # shared libraries
@@ -121,8 +167,8 @@ build_script:
 after_build:
   - cmd: cd C:/boost
   - cmd: dir
-  - 7z a boost-python-1.82.0_%ARCH%_py%PY_VER%.zip C:/boost
-  - move boost-python-1.82.0_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
+  - 7z a boost-python-%BOOST_VERSION%_%ARCH%_py%PY_VER%.zip C:/boost
+  - move boost-python-%BOOST_VERSION%_%ARCH%_py%PY_VER%.zip c:/projects/boost-ci/
 
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,9 @@ environment:
           using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
 
 init:
+  - cmd: echo "List all projects and python versions"
+  - cmd: dir "C:\projects\"
+  - cmd: dir "C:\"
   #RDP from start
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ init:
   # Boost
   - cmd: cd "C:\projects\"
   - cmd: md boost_build
-  - appveyor DownloadFile https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.zip
+  - appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.zip
   - cmd: 7z -y x boost_1_73_0.zip -oC:\projects\boost_build\
 
   # adding a boost-config.jam file

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
 
 environment:
   BOOST_VERSION: "1.82.0"
+  BOOST_VERSION_UNDERSCORED: "1_82_0"
   matrix:
   # # Python 3.6
   #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -123,7 +124,6 @@ environment:
           using python : 3.11 : c:/python311-x64/python.exe : c:/python311-x64/include : c:/python311-x64/libs ;
 
 init:
-  - cmd: set BOOST_VERSION_UNDERSCORED=%BOOST_VERSION:.=_%
   - cmd: echo %BOOST_VERSION_UNDERSCORED%
   - cmd: echo "List all projects and Python versions"
   - cmd: dir "C:\projects\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,7 +162,6 @@ build_script:
   # shared libraries
   - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=shared runtime-link=shared install
 
-
 after_build:
   - cmd: cd C:/boost
   - cmd: dir


### PR DESCRIPTION
To support Py39 and Py310 (issue: https://gitlab.com/tango-controls/pytango/-/issues/437), we need to update boost.
For that, I used the newest version of boost: 1.82.0.

Here is unofficial release on my fork repo https://github.com/mnabywan/boost-ci/releases/tag/1.82.0


Changes:
- use boost 1.82.0
- Add Py39, 310 and 311
- Use MSVC 2019 (not sure if it save for older Python versions)
- New naming convention (ex. v142_x64 and x142_x86)