### PR TITLE
Update to Boost 1.83.0, support Python 3.9 to 3.12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,73 +1,9 @@
 version: 1.0.{build}
-branches:
-  only:
-    - master
-    - support-new-python-versions
 
 environment:
-  BOOST_VERSION: "1.82.0"
-  BOOST_VERSION_UNDERSCORED: "1_82_0"
+  BOOST_VERSION: "1.83.0"
+  BOOST_VERSION_UNDERSCORED: "1_83_0"
   matrix:
-  # Python 3.6
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v142_x86
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python36\
-      PY_VER: 36
-      BOOST_CFG: >-
-          using python : 3.6 : c:/python36/python.exe : c:/python36/include : c:/python36/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v142_x64
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python36-x64\
-      PY_VER: 36
-      BOOST_CFG: >-
-          using python : 3.6 : c:/python36-x64/python.exe : c:/python36-x64/include : c:/python36-x64/libs ;
-
-  # Python 3.7
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v142_x86
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python37\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37/python.exe : c:/python37/include : c:/python37/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v142_x64
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python37-x64\
-      PY_VER: 37
-      BOOST_CFG: >-
-          using python : 3.7 : c:/python37-x64/python.exe : c:/python37-x64/include : c:/python37-x64/libs ;
-
-  # Python 3.8
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: win32
-      ADDR_MODEL: 32
-      ARCH: v142_x86
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python38\
-      PY_VER: 38
-      BOOST_CFG: >-
-          using python : 3.8 : c:/python38/python.exe : c:/python38/include : c:/python38/libs ;
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      platform: x64
-      ADDR_MODEL: 64
-      ARCH: v142_x64
-      MSVCVERSION: 14.2
-      PYTHONPATH: c:\Python38-x64\
-      PY_VER: 38
-      BOOST_CFG: >-
-          using python : 3.8 : c:/python38-x64/python.exe : c:/python38-x64/include : c:/python38-x64/libs ;
-
   # Python 3.9
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       platform: win32
@@ -128,9 +64,31 @@ environment:
       BOOST_CFG: >-
           using python : 3.11 : c:/python311-x64/python.exe : c:/python311-x64/include : c:/python311-x64/libs ;
 
+  # Python 3.12
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
+      PYTHON_DOWNLOAD_URL: https://www.python.org/ftp/python/3.12.0/python-3.12.0.exe
+      PYTHONPATH: c:\Python312\
+      PY_VER: 312
+      BOOST_CFG: >-
+          using python : 3.12 : c:/python312/python.exe : c:/python312/include : c:/python312/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
+      PYTHON_DOWNLOAD_URL: https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe
+      PYTHONPATH: c:\Python312-x64\
+      PY_VER: 312
+      BOOST_CFG: >-
+          using python : 3.12 : c:/python312-x64/python.exe : c:/python312-x64/include : c:/python312-x64/libs ;
+
 init:
   #RDP from start
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # Boost
   - cmd: cd "C:\projects\"
   - cmd: md boost_build
@@ -146,6 +104,21 @@ install:
   # Setting Visual Compiler
   - cmd: echo "Platform='%Platform%'"
   - cmd: set PYTHONPATH=%PYTHONPATH%
+  # install Python, if necessary
+  - ps: |
+      if (!(Test-Path -Path $env:PYTHONPATH) -and $env:PYTHON_DOWNLOAD_URL) {
+        Write-Host "Installing Python $($env:PY_VER)" -ForegroundColor Cyan
+
+        Write-Host "Downloading $($env:PYTHON_DOWNLOAD_URL)..."
+        $exePath = "$env:TEMP\python-installer.exe"
+        (New-Object Net.WebClient).DownloadFile($env:PYTHON_DOWNLOAD_URL, $exePath)
+
+        Write-Host "Installing..."
+        cmd /c start /wait $exePath /quiet TargetDir="$env:PYTHONPATH" Shortcuts=0 Include_launcher=1 InstallLauncherAllUsers=1 Include_debug=1
+        Remove-Item $exePath
+
+        Write-Host "Installed Python $($env:PY_VER) to $($env:PYTHONPATH)" -ForegroundColor Green
+      }
   # building bootstrap
   - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
   - cmd: C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/bootstrap.bat


### PR DESCRIPTION
Use latest Boost, drop very old Python versions, and add the recently released 3.12.

AppVeyor doesn't currently have a Windows image with Python 3.12, so install it if necessary.

Allow any branch to be built - useful with the branch/PR approach we are using for development.

Disable RDP at start.  Only needed for debugging.