### PR TITLE
Update boost to 1.85.0, with NumPy 2 support (patched)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 1.0.{build}
 
 environment:
-  BOOST_VERSION: "1.83.0"
-  BOOST_VERSION_UNDERSCORED: "1_83_0"
+  BOOST_VERSION: "1.85.0"
+  BOOST_VERSION_UNDERSCORED: "1_85_0"
   matrix:
   # Python 3.9
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -119,6 +119,8 @@ install:
 
         Write-Host "Installed Python $($env:PY_VER) to $($env:PYTHONPATH)" -ForegroundColor Green
       }
+  # apply patches to Boost
+  - cmd: patch -uN C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/libs/python/src/numpy/dtype.cpp C:/projects/boost-ci/patches/support-numpy-2.0.0b1.patch
   # building bootstrap
   - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
   - cmd: C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/bootstrap.bat

--- a/patches/support-numpy-2.0.0b1.patch
+++ b/patches/support-numpy-2.0.0b1.patch
@@ -1,0 +1,28 @@
+From 8ac13ee041e575a5b2af196dfd5088d9bdf90700 Mon Sep 17 00:00:00 2001
+From: Alexis DUBURCQ <alexis.duburcq@gmail.com>
+Date: Fri, 15 Mar 2024 14:10:16 +0100
+Subject: [PATCH] Support numpy 2.0.0b1
+
+---
+ libs/python/libs/python/src/numpy/dtype.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libs/python/src/numpy/dtype.cpp b/libs/python/src/numpy/dtype.cpp
+index 88a20a27..da30d192 100644
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -98,7 +98,13 @@ python::detail::new_reference dtype::convert(object const & arg, bool align)
+   return python::detail::new_reference(reinterpret_cast<PyObject*>(obj));
+ }
+ 
+-int dtype::get_itemsize() const { return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;}
++int dtype::get_itemsize() const {
++#if NPY_ABI_VERSION < 0x02000000
++  return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;
++#else
++  return PyDataType_ELSIZE(reinterpret_cast<PyArray_Descr*>(ptr()));
++#endif
++}
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+     // On Windows x64, the behaviour described on 


### PR DESCRIPTION
Use the latest version of boost, and include the [patch](https://github.com/boostorg/python/commit/0474de0f6cc9c6e7230aeb7164af2f7e4ccf74bf) that supports NumPy 2.0.0's C API changes.

Same patch used by conda-forge:  https://github.com/conda-forge/boost-feedstock/pull/207