### PR TITLE
Update boost to 1.86.0 and add Python 3.13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 1.0.{build}
 
 environment:
-  BOOST_VERSION: "1.85.0"
-  BOOST_VERSION_UNDERSCORED: "1_85_0"
+  BOOST_VERSION: "1.86.0"
+  BOOST_VERSION_UNDERSCORED: "1_86_0"
   matrix:
   # Python 3.9
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -121,6 +121,7 @@ install:
       }
   # apply patches to Boost
   - cmd: patch -uN C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/libs/python/src/numpy/dtype.cpp C:/projects/boost-ci/patches/support-numpy-2.0.0b1.patch
+  - cmd: patch -uN C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/libs/python/src/numpy/dtype.cpp C:/projects/boost-ci/patches/0003-Support-numpy-2.0.patch
   # building bootstrap
   - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
   - cmd: C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%/bootstrap.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,28 @@ environment:
       BOOST_CFG: >-
           using python : 3.12 : c:/python312-x64/python.exe : c:/python312-x64/include : c:/python312-x64/libs ;
 
+  # Python 3.13
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: win32
+      ADDR_MODEL: 32
+      ARCH: v142_x86
+      MSVCVERSION: 14.2
+      PYTHON_DOWNLOAD_URL: https://www.python.org/ftp/python/3.13.0/python-3.13.0.exe
+      PYTHONPATH: c:\Python313\
+      PY_VER: 313
+      BOOST_CFG: >-
+          using python : 3.13 : c:/python313/python.exe : c:/python313/include : c:/python313/libs ;
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      platform: x64
+      ADDR_MODEL: 64
+      ARCH: v142_x64
+      MSVCVERSION: 14.2
+      PYTHON_DOWNLOAD_URL: https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe
+      PYTHONPATH: c:\Python313-x64\
+      PY_VER: 313
+      BOOST_CFG: >-
+          using python : 3.13 : c:/python313-x64/python.exe : c:/python313-x64/include : c:/python313-x64/libs ;
+
 init:
   #RDP from start
   # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/patches/0003-Support-numpy-2.0.patch
+++ b/patches/0003-Support-numpy-2.0.patch
@@ -1,0 +1,38 @@
+diff --git a/libs/python/src/numpy/dtype.cpp b/libs/python/src/numpy/dtype.cpp
+index da30d192..1ce8c6ec 100644
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -107,32 +107,7 @@ int dtype::get_itemsize() const {
+ }
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+-    // On Windows x64, the behaviour described on 
+-    // http://docs.scipy.org/doc/numpy/reference/c-api.array.html for
+-    // PyArray_EquivTypes unfortunately does not extend as expected:
+-    // "For example, on 32-bit platforms, NPY_LONG and NPY_INT are equivalent".
+-    // This should also hold for 64-bit platforms (and does on Linux), but not
+-    // on Windows. Implement an alternative:
+-#ifdef _MSC_VER
+-    if (sizeof(long) == sizeof(int) &&
+-        // Manually take care of the type equivalence.
+-        ((a == dtype::get_builtin<long>() || a == dtype::get_builtin<int>()) &&
+-         (b == dtype::get_builtin<long>() || b == dtype::get_builtin<int>()) ||
+-         (a == dtype::get_builtin<unsigned int>() || a == dtype::get_builtin<unsigned long>()) &&
+-         (b == dtype::get_builtin<unsigned int>() || b == dtype::get_builtin<unsigned long>()))) {
+-        return true;
+-    } else {
+-        return PyArray_EquivTypes(
+-            reinterpret_cast<PyArray_Descr*>(a.ptr()),
+-            reinterpret_cast<PyArray_Descr*>(b.ptr())
+-        );
+-    }
+-#else
+-    return PyArray_EquivTypes(
+-        reinterpret_cast<PyArray_Descr*>(a.ptr()),
+-        reinterpret_cast<PyArray_Descr*>(b.ptr())
+-    );
+-#endif
++  return a == b;
+ }
+ 
+ namespace


### PR DESCRIPTION
- update boost to 1.86.0
- add extra patch for numpy 2 support (see https://github.com/conda-forge/boost-feedstock/pull/212)
- add python 3.13