### PR TITLE
Force --exec-prefix to C:\Boost

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -157,9 +157,9 @@ build:
 build_script:
   - cmd: cd C:/projects/boost_build/boost_%BOOST_VERSION_UNDERSCORED%
   # static libraries
-  - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=static runtime-link=static install
+  - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=static runtime-link=static install --exec-prefix=C:\Boost
   # shared libraries
-  - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=shared runtime-link=shared install
+  - cmd: b2 -j4 --with-python variant=release toolset=msvc-%MSVCVERSION% address-model=%ADDR_MODEL% threading=multi link=shared runtime-link=shared install --exec-prefix=C:\Boost
 
 after_build:
   - cmd: cd C:/boost


### PR DESCRIPTION
lib was installed under C:\python instead of C:\Boost in previous build: https://ci.appveyor.com/project/bourtemb/boost-ci/builds/50864762/job/irfkem6wdglh2dxw


According to `Jamroot`, `C:\Boost` should be the default on Windows for `EPREFIX`.
I didn't see any change between 1.85.0 and 1.86.0...

```
# Usage:
#
#   b2 [options] [properties] [install|stage]
#
#   Builds and installs Boost.
#
# Targets and Related Options:
#
#   install                 Install headers and compiled library files to the
#   =======                 configured locations (below).
#
#   --prefix=<PREFIX>       Install architecture independent files here.
#                           Default: C:\Boost on Windows
#                           Default: /usr/local on Unix, Linux, etc.
#
#   --exec-prefix=<EPREFIX> Install architecture dependent files here.
#                           Default: <PREFIX>
#
#   --libdir=<LIBDIR>       Install library files here.
#                           Default: <EPREFIX>/lib
#
#   --includedir=<HDRDIR>   Install header files here.
#                           Default: <PREFIX>/include
#
#   --cmakedir=<CMAKEDIR>   Install CMake configuration files here.
#                           Default: <LIBDIR>/cmake
```

Anyway forcing `EPREFIX` seems to work (https://ci.appveyor.com/project/NexeyaSGara/boost-ci-a51cb/builds/50945568/job/j494fpljg3h5gxym):

```
 Creating library bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\boost_python39-vc142-mt-x32-1_86.lib and object bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\boost_python39-vc142-mt-x32-1_86.exp
[00:07:27] common.copy C:\Boost\lib\boost_python39-vc142-mt-x32-1_86.dll
[00:07:27] bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\boost_python39-vc142-mt-x32-1_86.dll
[00:07:27]         1 file(s) copied.
[00:07:27] common.copy C:\Boost\lib\boost_python39-vc142-mt-x32-1_86.lib
[00:07:27] bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\boost_python39-vc142-mt-x32-1_86.lib
[00:07:27]         1 file(s) copied.
[00:07:27] common.copy C:\Boost\lib\cmake\boost_python-1.86.0\libboost_python-variant-vc142-mt-x32-1_86-shared-py3.9.cmake
[00:07:27] bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\libboost_python-variant-vc142-mt-x32-1_86-shared-py3.9.cmake
[00:07:27]         1 file(s) copied.
[00:07:27] common.copy C:\Boost\lib\cmake\boost_python-1.86.0\boost_python-config.cmake
[00:07:27] bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\install\boost_python-config.cmake
[00:07:27]         1 file(s) copied.
[00:07:27] common.copy C:\Boost\lib\cmake\boost_python-1.86.0\boost_python-config-version.cmake
[00:07:27] bin.v2\libs\python\build\msvc-14.2\release\x86_32\python-3.9\threading-multi\install\boost_python-config-version.cmake
[00:07:27]         1 file(s) copied.
```
